### PR TITLE
fix: 게시물 목록 프로필 이미지 링크 수정, 게시글 이미지 등록시 특수문자 거르는 기능추가

### DIFF
--- a/src/components/JobBoard-edit/hook.ts
+++ b/src/components/JobBoard-edit/hook.ts
@@ -139,11 +139,28 @@ const useJobBoardEdit = () => {
     }
   };
 
+  // 파일 이름을 sanitize하는 함수
+  const sanitizeFileName = (fileName: string): string => {
+    // 영문, 숫자, 점(.), 밑줄(_), 대시(-)를 제외한 모든 문자를 언더스코어(_)로 치환
+    return fileName.replace(/[^a-zA-Z0-9._-]/g, "_");
+  };
+
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (files) {
       const fileArray = Array.from(files);
-      setValue("newImages", fileArray, { shouldValidate: true });
+      const sanitizedFiles = fileArray.map((file) => {
+        const newName = sanitizeFileName(file.name);
+        if (newName !== file.name) {
+          return new File([file], newName, { type: file.type });
+        }
+        return file;
+      });
+      const existingFiles = watch("newImages") || [];
+      setValue("newImages", [...existingFiles, ...sanitizedFiles], {
+        shouldValidate: true,
+      });
+      event.target.value = "";
     }
   };
 

--- a/src/components/JobBoard-list/index.tsx
+++ b/src/components/JobBoard-list/index.tsx
@@ -60,7 +60,14 @@ const JobBoardList = () => {
                 {/* 상태 및 아이콘 */}
                 <div className="text-sm flex items-center mt-1 justify-between">
                   <div className="flex space-x-1">
-                    <div className="w-5 h-5 bg-gray-300 rounded-full flex items-center justify-center" />
+                    <div
+                      className="w-5 h-5 bg-gray-300 rounded-full flex items-center justify-center bg-cover bg-no-repeat bg-center"
+                      style={{
+                        backgroundImage: `url(${
+                          board.writeUserProfileImage || ""
+                        })`,
+                      }}
+                    />
                     <span className="text-sm text-text-quaternary">
                       {board.writeUserName}
                     </span>

--- a/src/components/JobBoard-new/hook.ts
+++ b/src/components/JobBoard-new/hook.ts
@@ -106,11 +106,28 @@ export const useJobBoardNew = () => {
     }
   };
 
+  // 파일 이름을 sanitize하는 함수
+  const sanitizeFileName = (fileName: string): string => {
+    // 영문, 숫자, 점(.), 밑줄(_), 대시(-)를 제외한 모든 문자를 언더스코어(_)로 치환
+    return fileName.replace(/[^a-zA-Z0-9._-]/g, "_");
+  };
+
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const files = event.target.files;
     if (files) {
       const fileArray = Array.from(files);
-      setValue("newImages", fileArray, { shouldValidate: true });
+      const sanitizedFiles = fileArray.map((file) => {
+        const newName = sanitizeFileName(file.name);
+        if (newName !== file.name) {
+          return new File([file], newName, { type: file.type });
+        }
+        return file;
+      });
+      const existingFiles = watch("newImages") || [];
+      setValue("newImages", [...existingFiles, ...sanitizedFiles], {
+        shouldValidate: true,
+      });
+      event.target.value = "";
     }
   };
 


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> ex. #이슈번호, #이슈번호

## 📝 작업 기간

> 10분

## 📝 작업 내용

> 게시물 목록에 프로필 이미지가 보이지 않는 문제 해결
이미지 이름에 특수문자가 있을 시 배포가 되지않는 문제를 잡아줌

### 스크린샷 (선택)

> 작업한 화면에 대한 스크린샷을 올려주세요.

## 💬 리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요.
> ex. 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
